### PR TITLE
Bump commons-io from 2.4 to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.7</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bumps commons-io from 2.4 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>