### PR TITLE
Bump commons-beanutils from 1.8.0 to 1.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>1.8.0</version>
+			<version>1.9.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bumps commons-beanutils from 1.8.0 to 1.9.2.

Signed-off-by: dependabot[bot] <support@github.com>